### PR TITLE
Dockerfile: Refactor Dockerfiles to separate WASM target addition and build steps

### DIFF
--- a/images/spin-keyvalue/Dockerfile
+++ b/images/spin-keyvalue/Dockerfile
@@ -1,7 +1,8 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
+RUN rustup target add wasm32-wasip1
 COPY . .
-RUN rustup target add wasm32-wasip1 && cargo build --target wasm32-wasip1 --release
+RUN cargo build --target wasm32-wasip1 --release
 
 FROM scratch
 COPY --from=build /opt/build/spin.toml ./spin.toml

--- a/images/spin-mqtt-message-logger/Dockerfile
+++ b/images/spin-mqtt-message-logger/Dockerfile
@@ -1,7 +1,8 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
+RUN rustup target add wasm32-wasip1
 COPY . .
-RUN rustup target add wasm32-wasip1 && cargo build --target wasm32-wasip1 --release
+RUN cargo build --target wasm32-wasip1 --release
 
 FROM scratch
 COPY --from=build /opt/build/target/wasm32-wasip1/release/mqtt_message_logger.wasm ./target/wasm32-wasip1/release/mqtt_message_logger.wasm

--- a/images/spin-multi-trigger-app/Dockerfile
+++ b/images/spin-multi-trigger-app/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
-COPY . .
 RUN rustup target add wasm32-wasip1
+COPY . .
 
 WORKDIR /opt/build/spin-http-trigger
 RUN cargo build --target wasm32-wasip1 --release

--- a/images/spin-multi-trigger-app/spin-redis-trigger/Dockerfile
+++ b/images/spin-multi-trigger-app/spin-redis-trigger/Dockerfile
@@ -1,7 +1,8 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
+RUN rustup target add wasm32-wasip1
 COPY . .
-RUN rustup target add wasm32-wasip1 && cargo build --target wasm32-wasip1 --release
+RUN cargo build --target wasm32-wasip1 --release
 
 FROM scratch
 COPY --from=build /opt/build/target/wasm32-wasip1/release/spin_redis_trigger.wasm ./target/wasm32-wasip1/release/spin_redis_trigger.wasm

--- a/images/spin-outbound-redis/Dockerfile
+++ b/images/spin-outbound-redis/Dockerfile
@@ -1,7 +1,8 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
+RUN rustup target add wasm32-wasip1
 COPY . .
-RUN rustup target add wasm32-wasip1 && cargo build --target wasm32-wasip1 --release
+RUN cargo build --target wasm32-wasip1 --release
 
 FROM scratch
 COPY --from=build /opt/build/target/wasm32-wasip1/release/spin_outbound_redis.wasm ./target/wasm32-wasip1/release/spin_outbound_redis.wasm

--- a/images/spin/Dockerfile
+++ b/images/spin/Dockerfile
@@ -1,13 +1,16 @@
 FROM --platform=${BUILDPLATFORM} rust:1.85 AS build
 WORKDIR /opt/build
+RUN rustup target add wasm32-wasip1
 COPY . .
-RUN rustup target add wasm32-wasip1 && cargo build --target wasm32-wasip1 --release
+RUN cargo build --target wasm32-wasip1 --release
 
 FROM --platform=linux/amd64 golang:1.23.2-bullseye AS build-go
 WORKDIR /opt/build
-COPY . .
 RUN curl -LO https://github.com/tinygo-org/tinygo/releases/download/v0.34.0/tinygo_0.34.0_amd64.deb && dpkg -i tinygo_0.34.0_amd64.deb
-RUN cd go-hello && tinygo build -target=wasi -o spin_go_hello.wasm main.go
+COPY . .
+WORKDIR /opt/build/go-hello
+RUN if [ -f go.mod ]; then go mod download; fi
+RUN tinygo build -target=wasi -o spin_go_hello.wasm main.go
 
 FROM scratch
 COPY --from=build /opt/build/target/wasm32-wasip1/release/spin_rust_hello.wasm ./target/wasm32-wasip1/release/spin_rust_hello.wasm

--- a/images/spin_dotnet/Dockerfile
+++ b/images/spin_dotnet/Dockerfile
@@ -1,14 +1,15 @@
 FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim-amd64 AS build
 WORKDIR /opt/build
-COPY . .
 RUN apt-get update && apt-get install xz-utils
 RUN curl -LO https://github.com/bytecodealliance/wizer/releases/download/dev/wizer-dev-x86_64-linux.tar.xz \
     && tar -xvf wizer-dev-x86_64-linux.tar.xz \
     && rm wizer-dev-x86_64-linux.tar.xz \
     && install wizer-dev-x86_64-linux/wizer /usr/local/bin
 
+FROM build AS build-dotnet
+COPY . .
 RUN dotnet build -c Release 
 
 FROM scratch
-COPY --from=build /opt/build/bin/Release/net7.0/MyTestProject.wasm ./bin/Release/net7.0/MyTestProject.wasm
-COPY --from=build /opt/build/spin.toml .
+COPY --from=build-dotnet /opt/build/bin/Release/net7.0/MyTestProject.wasm ./bin/Release/net7.0/MyTestProject.wasm
+COPY --from=build-dotnet /opt/build/spin.toml .


### PR DESCRIPTION
This is to optimize the build process and reduce the number of layers in the Docker images.

FYI @jprendes