### PR TITLE
node-installer: fixes for containerd 2

### DIFF
--- a/node-installer/script/installer.sh
+++ b/node-installer/script/installer.sh
@@ -69,7 +69,7 @@ cp /assets/containerd-shim-spin-v2 $NODE_ROOT$KWASM_DIR/bin/
 
 if ! grep -q spin $NODE_ROOT$CONTAINERD_CONF; then
     echo "Adding Spin runtime to containerd"
-    if $IS_K3S; then
+    if grep -q "version = 3" $NODE_ROOT$CONTAINERD_CONF; then
         echo '
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes."spin"]
     runtime_type = "'$KWASM_DIR'/bin/containerd-shim-spin-v2"
@@ -88,7 +88,7 @@ fi
 # configure SystemdCgroup
 if ! grep -q 'runtimes.spin.options' $NODE_ROOT$CONTAINERD_CONF && [ "$SYSTEMD_CGROUP" = "true" ]; then
     echo "Setting SystemdCgroup to $SYSTEMD_CGROUP in Spin containerd configuration"
-    if $IS_K3S; then
+    if grep -q "version = 3" $NODE_ROOT$CONTAINERD_CONF; then
         echo '
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.spin.options]
     SystemdCgroup = '$SYSTEMD_CGROUP'

--- a/node-installer/script/installer.sh
+++ b/node-installer/script/installer.sh
@@ -63,6 +63,11 @@ mkdir -p $NODE_ROOT$KWASM_DIR/bin/
 
 cp /assets/containerd-shim-spin-v2 $NODE_ROOT$KWASM_DIR/bin/
 
+# A bug in containerd makes BinaryName not work with shim not in PATH, so this statically links the kwasm installation to path
+# https://github.com/containerd/containerd/issues/11480
+mkdir -p $NODE_ROOT/usr/local/bin/
+ln -s $KWASM_DIR/bin/containerd-shim-spin-v2 $NODE_ROOT/usr/local/bin/containerd-shim-spin
+
 # K3S and RKE2 can detect spin shim themselves, no need to configure
 # https://github.com/k3s-io/k3s/pull/9519
 if ! ( $IS_K3S || $IS_RKE2_AGENT ) && ! grep -q spin $NODE_ROOT$CONTAINERD_CONF; then


### PR DESCRIPTION
- **node-installer: detect containerd config version instead of $IS_K3S**
- **node-installer: K3S & RKE2 can detect spin shim, no need to configure**
- **node-installer: fix K3S by linking shim to PATH**

As discussed in https://github.com/spinframework/containerd-shim-spin/issues/231#issuecomment-2756971572

