### PR TITLE
Force update shim path symbolic link if one already exists

### DIFF
--- a/node-installer/script/installer.sh
+++ b/node-installer/script/installer.sh
@@ -66,7 +66,7 @@ cp /assets/containerd-shim-spin-v2 $NODE_ROOT$KWASM_DIR/bin/
 # A bug in containerd makes BinaryName not work with shim not in PATH, so this statically links the kwasm installation to path
 # https://github.com/containerd/containerd/issues/11480
 mkdir -p $NODE_ROOT/usr/local/bin/
-ln -s $KWASM_DIR/bin/containerd-shim-spin-v2 $NODE_ROOT/usr/local/bin/containerd-shim-spin-v2
+ln -sf $KWASM_DIR/bin/containerd-shim-spin-v2 $NODE_ROOT/usr/local/bin/containerd-shim-spin-v2
 
 # K3S and RKE2 can detect spin shim themselves, no need to configure
 # https://github.com/k3s-io/k3s/pull/9519


### PR DESCRIPTION
Currently, rerunning the node-installer causes this error due to a preexisting link:
```sh
Events:
  Type    Reason   Age   From     Message
  ----    ------   ----  ----     -------
  Normal  Pulling  15s   kubelet  Pulling image "ghcr.io/spinframework/containerd-shim-spin/node-installer:20250331-171727-g57712f0"
  Normal  Pulled   13s   kubelet  Successfully pulled image "ghcr.io/spinframework/containerd-shim-spin/node-installer:20250331-171727-g57712f0" in 2.138s (2.138s including waiting). Image size: 29342804 bytes.
  Normal  Created  13s   kubelet  Created container: kwasm-provision
  Normal  Started  13s   kubelet  Started container kwasm-provision
Kates-MacBook-Pro :: ~ » k logs aks-agentpool-39718514-vmss000000-provision-kwasm-f9wlf -n kwasm
ln: /mnt/node-root/usr/local/bin/containerd-shim-spin-v2: File exists
```