### PR TITLE
chore: bump workload tag for v0.19.0

### DIFF
--- a/deployments/workloads/workload.yaml
+++ b/deployments/workloads/workload.yaml
@@ -15,7 +15,7 @@ spec:
       runtimeClassName: wasmtime-spin
       containers:
         - name: spin-hello
-          image: ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.18.0
+          image: ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.19.0
           command: ["/"]
           resources: # limit the resources to 128Mi of memory and 100m of CPU
             limits:

--- a/node-installer/tests/integration-test-k3s.sh
+++ b/node-installer/tests/integration-test-k3s.sh
@@ -56,7 +56,7 @@ if ! kubectl get pods -n kwasm | grep -q "k3s-provision-kwasm.*Completed"; then
 fi
 
 echo "=== Step 4: Apply the workload ==="
-sudo k3s ctr images pull ghcr.io/spinkube/containerd-shim-spin/examples/spin-rust-hello:v0.18.0
+sudo k3s ctr images pull ghcr.io/spinframework/containerd-shim-spin/examples/spin-rust-hello:v0.19.0
 kubectl apply -f ./tests/workloads/workload.yaml
 
 echo "Waiting for deployment to be ready..."


### PR DESCRIPTION
follow up to https://github.com/spinframework/containerd-shim-spin/pull/303#discussion_r2021751890

node installer tests should not be triggered (and fail) since PRing from fork